### PR TITLE
Update node-emoji

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yurnalist",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Elegant console output, borrowed from Yarn",
   "main": "dist/index.js",
   "repository": "https://github.com/0x80/yurnalist",
@@ -19,7 +19,7 @@
     "is-ci": "^1.0.10",
     "leven": "^2.0.0",
     "loud-rejection": "^1.2.0",
-    "node-emoji": "^1.0.4",
+    "node-emoji": "^1.8.1",
     "object-path": "^0.11.2",
     "read": "^1.0.7",
     "rimraf": "^2.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2357,6 +2357,10 @@ lodash.pickby@^4.0.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"
 
+lodash.toarray@^4.4.0:
+  version "4.4.0"
+  resolved "https://npm-registry.biw-services.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
+
 lodash@^4.0.0, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
@@ -2464,11 +2468,11 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
-node-emoji@^1.0.4:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.5.1.tgz#fd918e412769bf8c448051238233840b2aff16a1"
+node-emoji@^1.8.1:
+  version "1.8.1"
+  resolved "https://npm-registry.biw-services.com/node-emoji/-/node-emoji-1.8.1.tgz#6eec6bfb07421e2148c75c6bba72421f8530a826"
   dependencies:
-    string.prototype.codepointat "^0.2.0"
+    lodash.toarray "^4.4.0"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -3129,10 +3133,6 @@ string-width@^2.0.0:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^3.0.0"
-
-string.prototype.codepointat@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/string.prototype.codepointat/-/string.prototype.codepointat-0.2.0.tgz#6b26e9bd3afcaa7be3b4269b526de1b82000ac78"
 
 string_decoder@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Gatsby uses yurnalist in its CLI tools, but yurnalist uses an old version node-emoji which is missing quite a few really great ones, such as 🤷‍♂️. I can't use the newer node-emoji in my Gatsby-powered site, because yarn is too smart.