### PR TITLE
Improve list

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,24 +163,21 @@ The following functions are available:
 
 Pretty-prints the `thing`.
 
-### list(key: string, items: Array<string>, hints?: Object)
+### list(title: string, items: Array<string>, hints?: Object)
 
 Generates a list of the provided items. Turns into a definition list if `hints`
-are provided. Note that the `key` is not used.
+are provided.
 
 Example of a simple list:
 
 ```
-const someList = ['bananas', 'tulips', 'eggs', 'bamischijf'];
-
-report.info('My grocery list');
-report.list('ignored', someList);
+report.list('My grocery list', ['bananas', 'tulips', 'eggs', 'bamischijf']);
 ```
 
-generates
+Outputs:
 
 ```
-info My grocery list
+list My grocery list
    - bananas
    - tulips
    - eggs
@@ -191,7 +188,7 @@ info My grocery list
 Example with hints:
 
 ```
-const someList = ['bananas', 'tulips', 'eggs', 'bamischijf'];
+const items = ['bananas', 'tulips', 'eggs', 'bamischijf'];
 
 const hints = {
   bananas: 'for baking',
@@ -200,12 +197,13 @@ const hints = {
   bamischijf: 'if they have it',
 };
 
-report.info('My grocery list');
-report.list('dunno', someList, hints);
+report.list('My grocery list', items, hints);
 ```
-generates
+
+Outputs:
+
 ```
-info My grocery list
+list My grocery list
     - bananas
       for baking
    - tulips

--- a/examples/list.js
+++ b/examples/list.js
@@ -3,8 +3,7 @@ const report = require('../dist');
 /* eslint-disable flowtype/require-return-type */
 const someList = ['bananas', 'tulips', 'eggs', 'bamischijf'];
 
-report.info('My grocery list');
-report.list('dunno', someList);
+report.list('My grocery list', someList);
 
 const hints = {
   bananas: 'for baking',
@@ -13,5 +12,4 @@ const hints = {
   bamischijf: 'if they have it',
 };
 
-report.info('The same list with hints');
-report.list('dunno', someList, hints);
+report.list('The same list with hints', someList, hints);

--- a/src/reporters/console/console-reporter.js
+++ b/src/reporters/console/console-reporter.js
@@ -134,7 +134,14 @@ export default class ConsoleReporter extends BaseReporter {
     this.log(String(value), {force: true});
   }
 
-  list(key: string, items: Array<string>, hints?: Object) {
+  list(title: string, items: Array<string>, hints?: Object) {
+    /**
+     * Because in the original Yarn code list() is called starting with a "key:
+     * string" argument that is ignored, we don't assume that a title has been
+     * passed in or is a valid string, to avoid creating a breaking change.
+     */
+    this._logCategory('list', 'magenta', typeof title === 'string' ? this.format.bold(title) : '');
+
     const gutterWidth = (this._lastCategorySize || 2) - 1;
 
     if (hints) {


### PR DESCRIPTION
* Adds a title argument for `list` in place of the ignored key argument
* Outputs a magenta category "list" when printing a list
* Updates readme and example for list